### PR TITLE
Incorrect instructions to run Hobbes tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are three levels of testing contained in the project:
 
 * client-side Hobbes.js tests: JavaScript-based browser-side tests that verify browser-side behavior. To test:
 
-    in the browser, open the page in 'Developer mode', open the left panel and switch to the 'Tests' tab and find the generated 'MyName Tests' and run them.
+    in the navigation, go the 'Operations' section and open the 'Testing' console; the left panel will allow you to run your tests.
 
 
 ## Maven settings


### PR DESCRIPTION
This has changed in AEM 6.2 with the introduction of the 'Testing' console.
BTW, where are located the Hobbes tests? (do we have some of them yet?)

cc @dnlek 
