### PR TITLE
use GCC processor for jQuery. fixes #101

### DIFF
--- a/ui.apps/src/main/content/jcr_root/etc/clientlibs/we-retail/vendor/jquery/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/etc/clientlibs/we-retail/vendor/jquery/.content.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[we-retail.jquery]"/>
+    categories="[we-retail.jquery]"
+    jsProcessor="[default:none,min:gcc]"/>


### PR DESCRIPTION
As described in #101, the jQuery library used by we.retail doesn't work with YUI compressor and per #97 we can't switch to GCC throughout. We should switch this one client library to use GCC.