### PR TITLE
fixes #104 - Product rollout does not produce tagged pages

### DIFF
--- a/core/src/main/java/we/retail/core/WeRetailCommerceServiceImpl.java
+++ b/core/src/main/java/we/retail/core/WeRetailCommerceServiceImpl.java
@@ -108,12 +108,12 @@ public class WeRetailCommerceServiceImpl extends AbstractJcrCommerceService impl
             }
 
             //
-            // Copy geometrixx-outdoors-namespaced tags from the product to the product page.
+            // Copy we-retail namespaced tags from the product to the product page.
             //
             if (CommerceHelper.copyTags(productData, productPage.getContentResource(),
                     new Predicate() {
                         public boolean evaluate(Object o) {
-                            return ((Tag) o).getNamespace().getName().equals("geometrixx-outdoors");
+                            return ((Tag) o).getNamespace().getName().equals("we-retail");
                         }
                     })) {
                 changed = true;


### PR DESCRIPTION
Replace 'geometrixx-outdoors' tag namespace with 'we-retail'.

With fix applied (note cq:tags prop):

![after](https://cloud.githubusercontent.com/assets/1048207/15750903/17db474a-28b6-11e6-8cad-f84efa4d405b.png)
