### PR TITLE
Feature/dynamicmedia productgrid image

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/we-retail/components/content/product-grid/item/item.js
+++ b/ui.apps/src/main/content/jcr_root/apps/we-retail/components/content/product-grid/item/item.js
@@ -38,7 +38,7 @@ use(function () {
         , variationLead = baseProduct.getProperty("variationLead", java.lang.String)
         , variants = [];
 
-    var imageResource = baseProduct.getImage();
+    var imageResource = baseProduct.getAsset();
     product.image = imageResource.adaptTo(org.apache.sling.api.resource.ValueMap).get("fileReference", java.lang.String);
     product.name = baseProduct.getTitle();
     product.description = baseProduct.getDescription();
@@ -84,11 +84,7 @@ use(function () {
     return product;
 
     function getProductProperties(product) {
-        var productImage = product.getImage();
-        var productImageResource = null;
-        if (productImage != null) {
-            productImageResource = resolver.getResource(productImage.getPath());
-        }
+        var productImageResource = product.getAsset();
 
         return {
             path: product.getPath(),

--- a/ui.apps/src/main/content/jcr_root/apps/we-retail/components/content/product-grid/item/item.js
+++ b/ui.apps/src/main/content/jcr_root/apps/we-retail/components/content/product-grid/item/item.js
@@ -39,7 +39,7 @@ use(function () {
         , variants = [];
 
     var imageResource = baseProduct.getAsset();
-    product.image = imageResource.adaptTo(org.apache.sling.api.resource.ValueMap).get("fileReference", java.lang.String);
+    product.image = imageResource.adaptTo(org.apache.sling.api.resource.ValueMap).get("fileReference", java.lang.String) + ".thumb.319.319.png";
     product.name = baseProduct.getTitle();
     product.description = baseProduct.getDescription();
     product.price = commerceSession.getProductPrice(baseProduct);


### PR DESCRIPTION
getImage method of AEM Commerce Product returns only assets that are images.
If we want to use Dynamic media or any other Asset as Product image we need to use getAsset method.
Moreover we need to use thumbnail for those assets because their original rendition is not an image.