### PR TITLE
Added 'we-retail.base.addon' category to page component

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/we-retail/components/structure/page/partials/footlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/we-retail/components/structure/page/partials/footlibs.html
@@ -17,7 +17,7 @@
      data-sly-use.wcmInit="/libs/wcm/foundation/components/page/initwcm.js">
 
     <!--/* Include the site client libraries (loading only the JS in the footer, CSS were loaded in the header) */-->
-    <sly data-sly-call="${clientlib.js @ categories='we-retail.base'}"/>
+    <sly data-sly-call="${clientlib.js @ categories='we-retail.base,we-retail.base.addon'}"/>
     <sly data-sly-test.templateCategories="${wcmInit.templateCategories}" data-sly-call="${clientLib.js @ categories=templateCategories}" />
     <sly data-sly-call="${clientlib.js @ categories='cq.social.scf'}"/>
     <sly data-sly-call="${clientlib.js @ categories='cq.social.hbs.quicksearch'}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/we-retail/components/structure/page/partials/headlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/we-retail/components/structure/page/partials/headlibs.html
@@ -20,7 +20,7 @@
      data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
     <sly data-sly-test.templateCategories="${wcmInit.templateCategories}"
          data-sly-call="${clientLib.css @ categories=templateCategories}" />
-    <sly data-sly-call="${clientlib.css @ categories='we-retail.base'}"/>
+    <sly data-sly-call="${clientlib.css @ categories='we-retail.base,we-retail.base.addon'}"/>
     <sly data-sly-call="${clientlib.css @ categories='cq.social.hbs.quicksearch'}"/>
 </sly>
 


### PR DESCRIPTION
addon category will allow addon packages to include clientlibs without need to override any component or clientlib