### PR TITLE
Fixing Order tests.

### DIFF
--- a/core/src/test/java/we/retail/core/model/Constants.java
+++ b/core/src/test/java/we/retail/core/model/Constants.java
@@ -36,7 +36,7 @@ public class Constants {
     public static final String BILLING_ADDRESS = "John Doe, 601 Townsend St 3rd floor, US-94103 San Francisco, CA";
     public static final String SHIPPING_ADDRESS = "John Doe, 94103 San Francisco, CA";
     public static final String ORDER_STATUS = "Processing";
-    public static final String ORDER_DATE = "Mon Dec 12 2016 16:42:15 GMT+0100";
+    public static final String ORDER_DATE = "2016:12:12 16:42:15";
     public static final String ORDER_LIST_ID = "201612121";
 
     public static final int ENTRIES_SIZE = 2;

--- a/core/src/test/java/we/retail/core/model/OrderHistoryModelTest.java
+++ b/core/src/test/java/we/retail/core/model/OrderHistoryModelTest.java
@@ -43,7 +43,7 @@ import we.retail.core.model.OrderHistoryModel.PlacedOrderWrapper;
 public class OrderHistoryModelTest {
 
     private static final String DUMMY_ORDER_ID = "dummy-order-id";
-    private static final String DUMMY_ORDER_DATE = "Sun Dec 11 2016 16:42:15 GMT+0100";
+    private static final String DUMMY_ORDER_DATE = "2016:12:11 16:42:15";
     private static final String DUMMY_ORDER_LIST_ID = "201612110";
 
     @Rule


### PR DESCRIPTION
Hi,

I created this simple pull request because I'm getting a build failure in Order tests in we.retail.core.model package.

The issue is that the dates are defined with an English Locale (`Sun Dec...`), SimpleDateFormat instead is expecting  a French  Locale ( I have a French laptop ... ). in this case the Parser com.day.cq.dam.commons.util.DateParser returns a null.

In code `Sun Dec 11 2016 16:42:15 GMT+0100`
SimpleDateFormat expects  `dim. déc. 11 2016 16:42:15 GMT+0100`

 
My build stack trace 
<img width="987" alt="capture d ecran 2017-10-01 a 19 21 44" src="https://user-images.githubusercontent.com/1160243/31057133-cce021d2-a6dd-11e7-8194-cdaf521ec605.png">

The fix i did is to remove the locale from dates which in my opinion is not used here.

An other solution mybe to not use aem Parser and instead use SimpleDateFormat with fixed English locale. like `new SimpleDateFormat("EEE MMM dd yyyy HH:mm:ss \'GMT\'Z", Locale.ENGLISH)`

Kind Regards 
Abdellah.
