### PR TITLE
Fixing build issue in  Order tests

### DIFF
--- a/core/src/test/java/we/retail/core/model/Constants.java
+++ b/core/src/test/java/we/retail/core/model/Constants.java
@@ -15,7 +15,11 @@
  */
 package we.retail.core.model;
 
+import org.apache.sling.commons.json.jcr.JsonItemWriter;
+
 import java.math.BigDecimal;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 public class Constants {
 
@@ -55,4 +59,6 @@ public class Constants {
 
     public static final String ORDER_ID = "orderId";
     public static final String ORDER_PLACED = "orderPlaced";
+
+    public static final DateFormat W3C_DATE_FORMAT = new SimpleDateFormat("EEE MMM dd yyyy HH:mm:ss \'GMT\'Z", JsonItemWriter.DATE_FORMAT_LOCALE);
 }

--- a/core/src/test/java/we/retail/core/model/OrderHistoryModelTest.java
+++ b/core/src/test/java/we/retail/core/model/OrderHistoryModelTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import com.adobe.cq.commerce.api.CommerceService;
 import com.adobe.cq.commerce.common.PriceFilter;
 import com.adobe.cq.sightly.WCMBindings;
-import com.day.cq.dam.commons.util.DateParser;
 import com.day.cq.wcm.api.Page;
 
 import common.AppAemContext;
@@ -72,7 +71,7 @@ public class OrderHistoryModelTest {
         // The dummy order is inserted first but should appear second in the test (see below)
         MockDefaultJcrPlacedOrder dummyOrder = new MockDefaultJcrPlacedOrder(null, DUMMY_ORDER_ID, orderResource);
         dummyOrder.setOrderId(DUMMY_ORDER_ID);
-        dummyOrder.setOrderPlacedDate(DateParser.parseDate(DUMMY_ORDER_DATE));
+        dummyOrder.setOrderPlacedDate(Constants.W3C_DATE_FORMAT.parse(DUMMY_ORDER_DATE));
         commerceSession.registerPlacedOrder(DUMMY_ORDER_ID, dummyOrder);
 
         // This is the "original" mocked order

--- a/core/src/test/java/we/retail/core/model/OrderModelTest.java
+++ b/core/src/test/java/we/retail/core/model/OrderModelTest.java
@@ -33,7 +33,6 @@ import com.adobe.cq.commerce.api.CommerceException;
 import com.adobe.cq.commerce.api.CommerceService;
 import com.adobe.cq.sightly.SightlyWCMMode;
 import com.adobe.cq.sightly.WCMBindings;
-import com.day.cq.dam.commons.util.DateParser;
 import com.day.cq.wcm.api.Page;
 
 import common.AppAemContext;
@@ -51,6 +50,7 @@ public class OrderModelTest {
 
     @Before
     public void setUp() throws Exception {
+
         Page page = context.currentPage(Constants.TEST_ORDER_PAGE);
         context.currentResource(Constants.TEST_ORDER_RESOURCE);
 
@@ -88,7 +88,7 @@ public class OrderModelTest {
         assertEquals(Constants.BILLING_ADDRESS, orderModel.getBillingAddress());
         assertEquals(Constants.SHIPPING_ADDRESS, orderModel.getShippingAddress());
         assertEquals(Constants.ORDER_STATUS, orderModel.getOrderStatus());
-        Date orderDate = DateParser.parseDate(Constants.ORDER_DATE);
+        Date orderDate = Constants.W3C_DATE_FORMAT.parse(Constants.ORDER_DATE);
         assertEquals(orderDate, orderModel.getOrderDate().getTime());
     }
 


### PR DESCRIPTION
Hi,

I created this simple pull request because I'm getting a build failure in Order tests in we.retail.core.model package.

The issue is that the dates are defined with an US Locale (`Sun Dec...`), SimpleDateFormat instead is expecting  a French  Locale ( I have a French laptop ... ). in this case the Parser com.day.cq.dam.commons.util.DateParser returns a null.

In code `Sun Dec 11 2016 16:42:15 GMT+0100`
SimpleDateFormat expects  `dim. déc. 11 2016 16:42:15 GMT+0100`

 
My build stack trace 
<img width="987" alt="capture d ecran 2017-10-01 a 19 21 44" src="https://user-images.githubusercontent.com/1160243/31057133-cce021d2-a6dd-11e7-8194-cdaf521ec605.png">

The fix i did is to remove the call for DateParser and use instead a static dateFormat with a fixed Locale.US to match the `org.apache.sling.testing.mock.sling.loader.ContentLoader` class which is used in those tests to loads json files.

Kind Regards 
Abdellah.
