### PR TITLE
Update to latest Core Components 2.4.0

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -98,12 +98,7 @@
                         <dependency>
                             <group>adobe/cq60</group>
                             <name>core.wcm.components.all</name>
-                            <version>[2.3.0,)</version>
-                        </dependency>
-                        <dependency>
-                            <group>adobe/cq60</group>
-                            <name>core.wcm.components.extension</name>
-                            <version>[1.0.10,)</version>
+                            <version>[2.4.0,)</version>
                         </dependency>
                     </dependencies>
                 </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/contentfragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/contentfragment/.content.xml
@@ -3,5 +3,5 @@
     jcr:description="Component that allows to display a single text element or multiple elements of a content fragment."
     jcr:primaryType="cq:Component"
     jcr:title="Content Fragment"
-    sling:resourceSuperType="core/wcm/extension/components/contentfragment/v1/contentfragment"
+    sling:resourceSuperType="core/wcm/components/contentfragment/v1/contentfragment"
     componentGroup="We.Retail"/>


### PR DESCRIPTION
Core Components no longer have core.wcm.components.extension after this https://github.com/adobe/aem-core-wcm-components/issues/493